### PR TITLE
Fix broken profile picture for null avatars

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -6,6 +6,7 @@ const browser_action_default_title = manifestData.browser_action.default_title;
 
 
 const base_LIVE_Url = "https://robertsspaceindustries.com/";
+const base_LIVECDN_Url = "https://cdn.robertsspaceindustries.com/";
 const base_PTU_Url = "https://ptu.cloudimperiumgames.com/";
 
 

--- a/js/page_contacts.js
+++ b/js/page_contacts.js
@@ -118,7 +118,7 @@ function display_contact(elem, id, friend)
 		});
 	}
 	
-	if (friend.avatar == null) friend.avatar = base_LIVE_Url + "rsi/static/tavern/d761352b9e3c2bf075630b791c4aca28.jpg";
+	if (friend.avatar == null) friend.avatar = base_LIVECDN_Url + "static/images/account/avatar_default_big.jpg";
 	
 	var badges = '';
 	


### PR DESCRIPTION
Fixes broken profile picture for users with no defined avatars on RSI website.

Defines a new URL - base_LIVECDN_Url as "https://cdn.robertsspaceindustries.com/" in background.js Modifies the default avatar to use base_LIVECDN_Url + "images/account/avatar_default_big.jpg"